### PR TITLE
Links to starling-lab/RFGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ A full [copy of the license](https://github.com/batflyer/RFGB/blob/master/LICENS
 The authors would like to thank Professor Sriraam Natarajan, Professor Gautam Kunapuli, and fellow members of the [StARLinG Lab](https://starling.utdallas.edu) at the University of Texas at Dallas.
 
 [license]:LICENSE
-[license img]:https://img.shields.io/github/license/batflyer/RFGB.svg?style=flat-square
+[license img]:https://img.shields.io/github/license/starling-lab/RFGB.svg?style=flat-square
 
-[release]: https://github.com/batflyer/RFGB/releases
-[release img]:https://img.shields.io/github/tag/batflyer/RFGB.svg?style=flat-square
+[release]: https://github.com/starling-lab/RFGB/releases
+[release img]:https://img.shields.io/github/tag/starling-lab/RFGB.svg?style=flat-square
 
-[build link]:https://travis-ci.org/batflyer/RFGB.svg?branch=master
-[build img]:https://img.shields.io/travis/batflyer/RFGB.svg?style=flat-square
+[build link]:https://travis-ci.org/starling-lab/RFGB.svg?branch=master
+[build img]:https://img.shields.io/travis/starling-lab/RFGB.svg?style=flat-square
 
-[codecov link]:https://codecov.io/gh/batflyer/RFGB?branch=master
-[codecov img]:https://img.shields.io/codecov/c/github/batflyer/RFGB/master.svg?style=flat-square
+[codecov link]:https://codecov.io/gh/starling-lab/RFGB?branch=master
+[codecov img]:https://img.shields.io/codecov/c/github/starling-lab/RFGB/master.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-A full [copy of the license](https://github.com/batflyer/RFGB/blob/master/LICENSE) is available in the base of this repository. For more information, see https://www.gnu.org/licenses/
+A full [copy of the license](https://github.com/starling-lab/RFGB/blob/master/LICENSE) is available in the base of this repository. For more information, see https://www.gnu.org/licenses/
 
 ## Acknowledgements
 


### PR DESCRIPTION
Updating shields.io links to point to a repository on the starling-lab group.