### PR TITLE
setTarget function

### DIFF
--- a/rfgb/Utils.py
+++ b/rfgb/Utils.py
@@ -85,65 +85,18 @@ class Data(object):
             print(data.target)
             'cancer(C)'
         """
-
-        def getBkTarget(bk, target):
-            for line in bk:
-                if line.split('(')[0] == target:
-                    return line
-
-        def getFirstPositiveInstance(regression):
-            if regression:
-                for example in self.examples.keys():
-                    predicate = example.split(' ')[0]
-                    if predicate.split('(')[0] == target:
-                        return predicate
-            else:
-                for posEx in self.pos.keys():
-                    if posEx.split('(')[0] == target:
-                        return posEx
-
-        targetSpecification = getBkTarget(bk, target)
-        targetSpecification = targetSpecification[:-1].split('(')[1].split(',')
-        targetSpecification = list(map(Utils.removeModeSymbols, targetSpecification))
-        #print(targetSpecification)
-
-        firstPositiveInstance = getFirstPositiveInstance(regression)
-
-        # Name of the predicate
-        targetPredicate = firstPositiveInstance.split('(')[0]
-
-        # Arity of the predicate
-        targetArity = len(firstPositiveInstance.split('(')[1].split(','))
+        # targetTypes are the types of variables in the target predicate.
+        targetTypes = [i[:-1].split('(')[1].split(',') for i in bk if target in i][0]
+        targetTypes = list(map(Utils.removeModeSymbols, targetTypes))
         
-        # Collect variables in accordance with the arity.
-
-        targetVariables = sample(Utils.UniqueVariableCollection, targetArity)
-        #print(targetVariables)
-
-        self.target = targetPredicate + "(" #construct target string
-        
-        for variable in targetVariables:
-            self.target += variable + ","
-            self.variableType[variable] = targetSpecification[targetVariables.index(variable)]
-        
-        self.target = self.target[:-1] + ")"
-
-        #print(self.variableType)
-        #print(self.target)
-
-        """
-        # @batflyer: Attempting to refactor the setTarget function.
-        
-        targetArity = len([i[:-1].split('(')[1].split(',') for i in bk if target in i][0])
+        targetArity = len(targetTypes)
         targetVariables = sample(Utils.UniqueVariableCollection, targetArity)
 
         self.target = target + '('
         for variable in targetVariables:
             self.target += variable + ','
-            self.variableType[variable] = targetSpecification[targetVariables.index(variable)]
+            self.variableType[variable] = targetTypes[targetVariables.index(variable)]
         self.target = self.target[:-1] + ')'
-
-        """
         
     def getTarget(self):
         '''returns the target'''

--- a/rfgb/Utils.py
+++ b/rfgb/Utils.py
@@ -67,40 +67,64 @@ class Data(object):
                 self.neg[example] = -0.5 #set initial gradient to 0-0.5 for negative
 
     def setTarget(self, bk, target, regression=False):
-        '''sets the target'''
-        
+        """
+        Sets self.target as a target string.
+
+        Example:
+
+            # Instantiate a data object.
+            data = Data(regression=False)
+            background = ['friends(+person,-person)', friends(-person,+person),
+                          'smokes(+person)', 'cancer(+person']
+            target = 'cancer'
+
+            # set the target as a string we will try to prove.
+            data.setTarget(background, target)
+            
+            print(data.target)
+            'cancer(C)'
+        """
+
         def getBkTarget(bk, target):
             for line in bk:
                 if line.split('(')[0] == target:
                     return line
 
-
+        def getFirstPositiveInstance(regression):
+            if regression:
+                for example in self.examples.keys():
+                    predicate = example.split(' ')[0]
+                    if predicate.split('(')[0] == target:
+                        return predicate
+            else:
+                for posEx in self.pos.keys():
+                    if posEx.split('(')[0] == target:
+                        return posEx
 
         targetSpecification = getBkTarget(bk, target)
-
         targetSpecification = targetSpecification[:-1].split('(')[1].split(',')
 
-        if regression:
-            for example in self.examples.keys():
-                predicate = example.split(' ')[0]
-                if predicate.split('(')[0] == target:
-                    firstPositiveInstance = predicate
-                    break
-        else:
-            for posEx in self.pos.keys():
-                if posEx.split('(')[0] == target:
-                    firstPositiveInstance = posEx
-                    break
-        
-        targetPredicate = firstPositiveInstance.split('(')[0] #get predicate name
-        targetArity = len(firstPositiveInstance.split('(')[1].split(',')) #get predicate arity
-        targetVariables = sample(Utils.UniqueVariableCollection,targetArity) #get some variables according to arity
-        self.target = targetPredicate+"(" #construct target string
-        for variable in targetVariables:
-            self.target += variable+","
-            self.variableType[variable] = targetSpecification[targetVariables.index(variable)]
-        self.target = self.target[:-1]+")"
+        firstPositiveInstance = getFirstPositiveInstance(regression)
 
+        # Name of the predicate
+        targetPredicate = firstPositiveInstance.split('(')[0]
+
+        # Arity of the predicate
+        targetArity = len(firstPositiveInstance.split('(')[1].split(','))
+        
+        # Collect variables in accordance with the arity.
+
+        targetVariables = sample(Utils.UniqueVariableCollection, targetArity)
+        print(targetVariables)
+
+        self.target = targetPredicate + "(" #construct target string
+        
+        for variable in targetVariables:
+            self.target += variable + ","
+            self.variableType[variable] = targetSpecification[targetVariables.index(variable)]
+        
+        self.target = self.target[:-1]+")"
+        
     def getTarget(self):
         '''returns the target'''
         return self.target
@@ -147,7 +171,7 @@ class Data(object):
         '''
         Calculates the variance of the regression values from a subset of the data.
         '''
-        print(examples)
+        #print(examples)
 
         if not examples:
             return 0

--- a/rfgb/Utils.py
+++ b/rfgb/Utils.py
@@ -66,25 +66,32 @@ class Data(object):
             if example.split('(')[0] == target:
                 self.neg[example] = -0.5 #set initial gradient to 0-0.5 for negative
 
-    def setTarget(self, bk, target, regression = False):
+    def setTarget(self, bk, target, regression=False):
         '''sets the target'''
-        targetSpecification = None
-        for line in bk:
-            if line.split('(')[0] == target:
-                targetSpecification = line
+        
+        def getBkTarget(bk, target):
+            for line in bk:
+                if line.split('(')[0] == target:
+                    return line
+
+
+
+        targetSpecification = getBkTarget(bk, target)
+
         targetSpecification = targetSpecification[:-1].split('(')[1].split(',')
-        firstPositiveInstance = None
-        if not regression:
-            for posEx in self.pos.keys(): #get the first positive example in the dictionary
-                if posEx.split('(')[0] == target:
-                    firstPositiveInstance = posEx
-                    break
-        elif regression:
-            for example in self.examples.keys(): #get first regression example
+
+        if regression:
+            for example in self.examples.keys():
                 predicate = example.split(' ')[0]
                 if predicate.split('(')[0] == target:
                     firstPositiveInstance = predicate
                     break
+        else:
+            for posEx in self.pos.keys():
+                if posEx.split('(')[0] == target:
+                    firstPositiveInstance = posEx
+                    break
+        
         targetPredicate = firstPositiveInstance.split('(')[0] #get predicate name
         targetArity = len(firstPositiveInstance.split('(')[1].split(',')) #get predicate arity
         targetVariables = sample(Utils.UniqueVariableCollection,targetArity) #get some variables according to arity

--- a/rfgb/Utils.py
+++ b/rfgb/Utils.py
@@ -69,13 +69,14 @@ class Data(object):
     def setTarget(self, bk, target, regression=False):
         """
         Sets self.target as a target string.
+        Sets self.variableType
 
         Example:
 
             # Instantiate a data object.
             data = Data(regression=False)
             background = ['friends(+person,-person)', friends(-person,+person),
-                          'smokes(+person)', 'cancer(+person']
+                          'smokes(+person)', 'cancer(+person)']
             target = 'cancer'
 
             # set the target as a string we will try to prove.
@@ -103,6 +104,8 @@ class Data(object):
 
         targetSpecification = getBkTarget(bk, target)
         targetSpecification = targetSpecification[:-1].split('(')[1].split(',')
+        targetSpecification = list(map(Utils.removeModeSymbols, targetSpecification))
+        #print(targetSpecification)
 
         firstPositiveInstance = getFirstPositiveInstance(regression)
 
@@ -115,7 +118,7 @@ class Data(object):
         # Collect variables in accordance with the arity.
 
         targetVariables = sample(Utils.UniqueVariableCollection, targetArity)
-        print(targetVariables)
+        #print(targetVariables)
 
         self.target = targetPredicate + "(" #construct target string
         
@@ -123,7 +126,24 @@ class Data(object):
             self.target += variable + ","
             self.variableType[variable] = targetSpecification[targetVariables.index(variable)]
         
-        self.target = self.target[:-1]+")"
+        self.target = self.target[:-1] + ")"
+
+        #print(self.variableType)
+        #print(self.target)
+
+        """
+        # @batflyer: Attempting to refactor the setTarget function.
+        
+        targetArity = len([i[:-1].split('(')[1].split(',') for i in bk if target in i][0])
+        targetVariables = sample(Utils.UniqueVariableCollection, targetArity)
+
+        self.target = target + '('
+        for variable in targetVariables:
+            self.target += variable + ','
+            self.variableType[variable] = targetSpecification[targetVariables.index(variable)]
+        self.target = self.target[:-1] + ')'
+
+        """
         
     def getTarget(self):
         '''returns the target'''
@@ -197,6 +217,29 @@ class Utils(object):
 
     data = None #attribute to store data (facts,positive and negative examples)
     UniqueVariableCollection = set(list(string.ascii_uppercase))
+
+    @staticmethod
+    def sigmoid(x):
+        '''returns sigmoid of x'''
+        return exp(x)/float(1+exp(x))
+
+    @staticmethod
+    def removeModeSymbols(inputString):
+        """
+        Returns a string with the mode symbols (+,-,#) removed.
+
+        Example:
+            >>> i = "#city"
+            >>> o = removeModeSymbols(i)
+            >>> print(o)
+            city
+
+            >>> i = ["+drinks", "-drink", "-city"]
+            >>> o = list(map(removeModeSymbols, i))
+            >>> print(o)
+            ["drinks", "drink", "city"]
+        """
+        return inputString.replace('+', '').replace('-', '').replace('#', '')
 
     @staticmethod
     def addVariableTypes(literal):
@@ -341,10 +384,6 @@ class Utils(object):
         
         return testData
 
-    @staticmethod
-    def sigmoid(x):
-        '''returns sigmoid of x'''
-        return exp(x)/float(1+exp(x))
 
     @staticmethod
     def cartesianProduct(itemSets):

--- a/rfgb/Utils.py
+++ b/rfgb/Utils.py
@@ -66,7 +66,7 @@ class Data(object):
             if example.split('(')[0] == target:
                 self.neg[example] = -0.5 #set initial gradient to 0-0.5 for negative
 
-    def setTarget(self, bk, target, regression=False):
+    def setTarget(self, bk, target):
         """
         Sets self.target as a target string.
         Sets self.variableType
@@ -291,7 +291,7 @@ class Utils(object):
             bk = fp.read().splitlines()
 
             Utils.data.setBackground(bk)
-            Utils.data.setTarget(bk, target, regression=regression)
+            Utils.data.setTarget(bk, target)
             #trainData.setBackground(bk)
             #trainData.setTarget(bk, target, regression=regression)
         

--- a/tests/rfgbtests/test_Utils.py
+++ b/tests/rfgbtests/test_Utils.py
@@ -1,20 +1,42 @@
+"""
+Copyright (C) 2017-2018 RFGB Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (at the base of this repository). If not,
+see <http://www.gnu.org/licenses/>
+"""
+
 import sys
 import unittest
+
+# Metadata
+__author__     = "Alexander L. Hayes (@batflyer)"
+__copyright__  = "Copyright (C) 2017-2018 RFGB Contributors"
+__license__    = "GPL-v3"
+__maintainer__ = "Alexander L. Hayes (@batflyer)"
+__email__      = "alexander@batflyer.net"
+__status__     = "Prototype"
+
+"""
+Unit tests for Utils.py
+
+Tests should be ordered in the same manner as they are defined in Utils.py
+"""
 
 sys.path.append('./rfgb/')
 from Utils import Utils
 
 class UtilsTest(unittest.TestCase):
-
-    def test_sigmoid(self):
-        self.assertEqual(Utils.sigmoid(-5), 0.006692850924284856)
-        self.assertEqual(Utils.sigmoid(-0.001), 0.49975000002083336)
-        self.assertEqual(Utils.sigmoid(0), 0.5)
-        self.assertEqual(Utils.sigmoid(0.0001), 0.5000249999999792)
-        self.assertEqual(Utils.sigmoid(0.01), 0.5024999791668749)
-        self.assertEqual(Utils.sigmoid(0.5), 0.6224593312018546)
-        self.assertEqual(Utils.sigmoid(1), 0.7310585786300049)
-        self.assertEqual(Utils.sigmoid(5), 0.9933071490757152)
 
     def test_read_test_data_toy_cancer(self):
         """
@@ -66,6 +88,19 @@ class UtilsTest(unittest.TestCase):
             self.assertTrue(float(eVal) in list(sampleData.examples.values()))
 
         self.assertEqual(sampleData.examples, {'medv(id348)': 23.1, 'medv(id369)': 50.0, 'medv(id344)': 23.9, 'medv(id152)': 19.6, 'medv(id120)': 19.3, 'medv(id53)': 25.0, 'medv(id422)': 14.2, 'medv(id115)': 18.5, 'medv(id235)': 29.0, 'medv(id448)': 12.6, 'medv(id3)': 34.7, 'medv(id211)': 21.7, 'medv(id334)': 22.2, 'medv(id313)': 19.4, 'medv(id13)': 21.7, 'medv(id42)': 26.6, 'medv(id439)': 84.0, 'medv(id45)': 21.2, 'medv(id183)': 37.9, 'medv(id212)': 19.3, 'medv(id374)': 13.8, 'medv(id238)': 31.5, 'medv(id294)': 23.9, 'medv(id7)': 22.9, 'medv(id62)': 16.0, 'medv(id153)': 15.3, 'medv(id345)': 31.2, 'medv(id163)': 50.0, 'medv(id341)': 18.7, 'medv(id50)': 19.4, 'medv(id208)': 22.5, 'medv(id167)': 50.0, 'medv(id70)': 20.9, 'medv(id143)': 13.4, 'medv(id217)': 23.3, 'medv(id29)': 18.4, 'medv(id181)': 39.8, 'medv(id342)': 32.7, 'medv(id59)': 23.3, 'medv(id27)': 16.6, 'medv(id188)': 32.0, 'medv(id435)': 11.7, 'medv(id173)': 23.1, 'medv(id10)': 18.9})
+
+    def test_sigmoid(self):
+        """
+        tests: sigmoid function.
+        """
+        self.assertEqual(Utils.sigmoid(-5), 0.006692850924284856)
+        self.assertEqual(Utils.sigmoid(-0.001), 0.49975000002083336)
+        self.assertEqual(Utils.sigmoid(0), 0.5)
+        self.assertEqual(Utils.sigmoid(0.0001), 0.5000249999999792)
+        self.assertEqual(Utils.sigmoid(0.01), 0.5024999791668749)
+        self.assertEqual(Utils.sigmoid(0.5), 0.6224593312018546)
+        self.assertEqual(Utils.sigmoid(1), 0.7310585786300049)
+        self.assertEqual(Utils.sigmoid(5), 0.9933071490757152)
         
 if __name__ == '__main__':
     unittest.main()

--- a/tests/rfgbtests/test_Utils.py
+++ b/tests/rfgbtests/test_Utils.py
@@ -55,17 +55,12 @@ class UtilsTest(unittest.TestCase):
         data.setPos(['cancer(Ulrich)', 'cancer(Odd)'], target)
 
         # setTarget has some random behavior, but always returns the target bound to a letter.
-        # 1. Check that cancer is part of the target string.
-
-        for _ in range(10):
-            data.setTarget(background, target)
-            self.assertTrue('cancer' in data.target)
-
-        # 2. Check that a random letter is bound to the target string.
-
         for _ in range(100):
             # Set the target (introducing a random variable).
             data.setTarget(background, target)
+
+            # Assert the presence of the target.
+            self.assertTrue(target in data.target)
 
             # Get the random variable.
             instance = data.target.split('(')[1][0]
@@ -87,13 +82,12 @@ class UtilsTest(unittest.TestCase):
         data.setBackground(background)
         data.setPos(['friends(Ulrich,Odd)', 'friends(Odd,Jeremy)'], target)
 
-        for _ in range(10):
-            data.setTarget(background, target)
-            self.assertTrue('friends' in data.target)
-
         for _ in range(100):
             # Set the target (introducing two random variables).
             data.setTarget(background, target)
+
+            # Assert the presence of the target.
+            self.assertTrue(target in data.target)
 
             # Get the two random variables.
             instance = data.target.split('(')[1].split(')')[0].split(',')
@@ -103,6 +97,36 @@ class UtilsTest(unittest.TestCase):
             self.assertTrue(instance[0] in Utils.UniqueVariableCollection)
             self.assertTrue(instance[1] in Utils.UniqueVariableCollection)
 
+    def test_setTarget_3(self):
+        """
+        tests: Data.setTarget (3-arity case).
+        """
+
+        target = 'drinks'
+        background = ['drinks(+person,-drink,-city)']
+        
+        data = Data(regression=False)
+        data.setPos(['drinks(Jeremy,Wine,Paris)', 'drinks(Ulrich,Beer,Frankfurt)'], target)
+
+        for _ in range(10):
+            data.setTarget(background, target)
+            self.assertTrue('drinks' in data.target)
+
+        for _ in range(100):
+            # Set the target (introducing three random variables).
+            data.setTarget(background, target)
+
+            # Assert the presence of the target.
+            self.assertTrue(target in data.target)
+
+            # Get the three random variables.
+            instance = data.target.split('(')[1].split(')')[0].split(',')
+
+            # Assert arity of drinks is 3, variables are not duplicated, and belong to UniqueVariableCollection.
+            self.assertEqual(len(instance), 3)
+            self.assertTrue(instance[0] in Utils.UniqueVariableCollection)
+            self.assertTrue(instance[1] in Utils.UniqueVariableCollection)
+            self.assertTrue(instance[2] in Utils.UniqueVariableCollection)
 
     def test_read_test_data_toy_cancer(self):
         """

--- a/tests/rfgbtests/test_Utils.py
+++ b/tests/rfgbtests/test_Utils.py
@@ -108,10 +108,6 @@ class UtilsTest(unittest.TestCase):
         data = Data(regression=False)
         data.setPos(['drinks(Jeremy,Wine,Paris)', 'drinks(Ulrich,Beer,Frankfurt)'], target)
 
-        for _ in range(10):
-            data.setTarget(background, target)
-            self.assertTrue('drinks' in data.target)
-
         for _ in range(100):
             # Set the target (introducing three random variables).
             data.setTarget(background, target)

--- a/tests/rfgbtests/test_Utils.py
+++ b/tests/rfgbtests/test_Utils.py
@@ -77,7 +77,6 @@ class UtilsTest(unittest.TestCase):
             # Set the target (introducing a random variable).
             data = Data(regression=False)
             data.setBackground(background)
-            data.setPos(['cancer(Ulrich)', 'cancer(Odd)'], target)
             data.setTarget(background, target)
 
             # Assert the presence of the target.
@@ -103,7 +102,6 @@ class UtilsTest(unittest.TestCase):
             # Set the target (introducing two random variables).
             data = Data(regression=False)
             data.setBackground(background)
-            data.setPos(['friends(Ulrich,Odd)', 'friends(Odd,Jeremy)'], target)
             data.setTarget(background, target)
 
             # Assert the presence of the target.

--- a/tests/rfgbtests/test_Utils.py
+++ b/tests/rfgbtests/test_Utils.py
@@ -34,9 +34,50 @@ Tests should be ordered in the same manner as they are defined in Utils.py
 """
 
 sys.path.append('./rfgb/')
+
+from Utils import Data
 from Utils import Utils
 
 class UtilsTest(unittest.TestCase):
+
+    def test_setTarget(self):
+        """
+        tests: Data.setTarget.
+        """
+
+        # Some setup that needs to take place.
+        
+        target = 'cancer'
+        background = ['friends(+person,-person)', 'friends(-person,+person)',
+                      'smokes(+person)', 'cancer(person)']
+        data = Data(regression=False)
+        data.setBackground(background)
+        data.setPos(['cancer(Ulrich)', 'cancer(Odd)'], target)
+
+        # setTarget has some random behavior, but always returns the target bound to a letter.
+        # 1. Check that cancer is part of the target string.
+        
+        data.setTarget(background, target)
+        self.assertTrue('cancer' in data.target)
+
+        data.setTarget(background, target)
+        self.assertTrue('cancer' in data.target)
+
+        data.setTarget(background, target)
+        self.assertTrue('cancer' in data.target)
+
+        # 2. Check that a random letter is bound to the target string.
+
+        for t in range(100):
+            # Set the target (introducing a random variable).
+            data.setTarget(background, target)
+
+            # Get the random variable.
+            instance = data.target.split('(')[1][0]
+
+            # Assert that the random variable belongs to the UniqueVariableCollection.
+            self.assertTrue(instance in Utils.UniqueVariableCollection)
+            
 
     def test_read_test_data_toy_cancer(self):
         """

--- a/tests/rfgbtests/test_Utils.py
+++ b/tests/rfgbtests/test_Utils.py
@@ -40,9 +40,9 @@ from Utils import Utils
 
 class UtilsTest(unittest.TestCase):
 
-    def test_setTarget(self):
+    def test_setTarget_1(self):
         """
-        tests: Data.setTarget.
+        tests: Data.setTarget (attribute case).
         """
 
         # Some setup that needs to take place.
@@ -56,19 +56,14 @@ class UtilsTest(unittest.TestCase):
 
         # setTarget has some random behavior, but always returns the target bound to a letter.
         # 1. Check that cancer is part of the target string.
-        
-        data.setTarget(background, target)
-        self.assertTrue('cancer' in data.target)
 
-        data.setTarget(background, target)
-        self.assertTrue('cancer' in data.target)
-
-        data.setTarget(background, target)
-        self.assertTrue('cancer' in data.target)
+        for _ in range(10):
+            data.setTarget(background, target)
+            self.assertTrue('cancer' in data.target)
 
         # 2. Check that a random letter is bound to the target string.
 
-        for t in range(100):
+        for _ in range(100):
             # Set the target (introducing a random variable).
             data.setTarget(background, target)
 
@@ -77,7 +72,37 @@ class UtilsTest(unittest.TestCase):
 
             # Assert that the random variable belongs to the UniqueVariableCollection.
             self.assertTrue(instance in Utils.UniqueVariableCollection)
-            
+
+    def test_setTarget_2(self):
+        """
+        tests: Data.setTarget (relation case).
+        """
+
+        # Some setup that needs to take place.
+        target = 'friends'
+        background = ['friends(+person,-person)', 'friends(-person,+person)',
+                      'smokes(+person)', 'cancer(person)']
+
+        data = Data(regression=False)
+        data.setBackground(background)
+        data.setPos(['friends(Ulrich,Odd)', 'friends(Odd,Jeremy)'], target)
+
+        for _ in range(10):
+            data.setTarget(background, target)
+            self.assertTrue('friends' in data.target)
+
+        for _ in range(100):
+            # Set the target (introducing two random variables).
+            data.setTarget(background, target)
+
+            # Get the two random variables.
+            instance = data.target.split('(')[1].split(')')[0].split(',')
+
+            # Assert arity of friendship is 2, and that variables belong to UniqueVariableCollection.
+            self.assertEqual(len(instance), 2)
+            self.assertTrue(instance[0] in Utils.UniqueVariableCollection)
+            self.assertTrue(instance[1] in Utils.UniqueVariableCollection)
+
 
     def test_read_test_data_toy_cancer(self):
         """

--- a/tests/rfgbtests/test_Utils.py
+++ b/tests/rfgbtests/test_Utils.py
@@ -40,6 +40,27 @@ from Utils import Utils
 
 class UtilsTest(unittest.TestCase):
 
+    def test_sigmoid(self):
+        """
+        tests: sigmoid function.
+        """
+        self.assertEqual(Utils.sigmoid(-5), 0.006692850924284856)
+        self.assertEqual(Utils.sigmoid(-0.001), 0.49975000002083336)
+        self.assertEqual(Utils.sigmoid(0), 0.5)
+        self.assertEqual(Utils.sigmoid(0.0001), 0.5000249999999792)
+        self.assertEqual(Utils.sigmoid(0.01), 0.5024999791668749)
+        self.assertEqual(Utils.sigmoid(0.5), 0.6224593312018546)
+        self.assertEqual(Utils.sigmoid(1), 0.7310585786300049)
+        self.assertEqual(Utils.sigmoid(5), 0.9933071490757152)
+
+    def test_removeModeSymbols(self):
+        """
+        tests: removeModeSymbols function.
+        """
+        self.assertEqual(Utils.removeModeSymbols("+drinks"), "drinks")
+        self.assertEqual(Utils.removeModeSymbols("-drinks"), "drinks")
+        self.assertEqual(Utils.removeModeSymbols("#drinks"), "drinks")
+
     def test_setTarget_1(self):
         """
         tests: Data.setTarget (attribute case).
@@ -50,13 +71,13 @@ class UtilsTest(unittest.TestCase):
         target = 'cancer'
         background = ['friends(+person,-person)', 'friends(-person,+person)',
                       'smokes(+person)', 'cancer(person)']
-        data = Data(regression=False)
-        data.setBackground(background)
-        data.setPos(['cancer(Ulrich)', 'cancer(Odd)'], target)
 
         # setTarget has some random behavior, but always returns the target bound to a letter.
         for _ in range(100):
             # Set the target (introducing a random variable).
+            data = Data(regression=False)
+            data.setBackground(background)
+            data.setPos(['cancer(Ulrich)', 'cancer(Odd)'], target)
             data.setTarget(background, target)
 
             # Assert the presence of the target.
@@ -78,12 +99,11 @@ class UtilsTest(unittest.TestCase):
         background = ['friends(+person,-person)', 'friends(-person,+person)',
                       'smokes(+person)', 'cancer(person)']
 
-        data = Data(regression=False)
-        data.setBackground(background)
-        data.setPos(['friends(Ulrich,Odd)', 'friends(Odd,Jeremy)'], target)
-
         for _ in range(100):
             # Set the target (introducing two random variables).
+            data = Data(regression=False)
+            data.setBackground(background)
+            data.setPos(['friends(Ulrich,Odd)', 'friends(Odd,Jeremy)'], target)
             data.setTarget(background, target)
 
             # Assert the presence of the target.
@@ -105,11 +125,11 @@ class UtilsTest(unittest.TestCase):
         target = 'drinks'
         background = ['drinks(+person,-drink,-city)']
         
-        data = Data(regression=False)
-        data.setPos(['drinks(Jeremy,Wine,Paris)', 'drinks(Ulrich,Beer,Frankfurt)'], target)
-
         for _ in range(100):
             # Set the target (introducing three random variables).
+            data = Data(regression=False)
+            data.setBackground(background)
+            data.setPos(['drinks(Jeremy,Wine,Paris)', 'drinks(Ulrich,Beer,Frankfurt)'], target)
             data.setTarget(background, target)
 
             # Assert the presence of the target.
@@ -175,18 +195,7 @@ class UtilsTest(unittest.TestCase):
 
         self.assertEqual(sampleData.examples, {'medv(id348)': 23.1, 'medv(id369)': 50.0, 'medv(id344)': 23.9, 'medv(id152)': 19.6, 'medv(id120)': 19.3, 'medv(id53)': 25.0, 'medv(id422)': 14.2, 'medv(id115)': 18.5, 'medv(id235)': 29.0, 'medv(id448)': 12.6, 'medv(id3)': 34.7, 'medv(id211)': 21.7, 'medv(id334)': 22.2, 'medv(id313)': 19.4, 'medv(id13)': 21.7, 'medv(id42)': 26.6, 'medv(id439)': 84.0, 'medv(id45)': 21.2, 'medv(id183)': 37.9, 'medv(id212)': 19.3, 'medv(id374)': 13.8, 'medv(id238)': 31.5, 'medv(id294)': 23.9, 'medv(id7)': 22.9, 'medv(id62)': 16.0, 'medv(id153)': 15.3, 'medv(id345)': 31.2, 'medv(id163)': 50.0, 'medv(id341)': 18.7, 'medv(id50)': 19.4, 'medv(id208)': 22.5, 'medv(id167)': 50.0, 'medv(id70)': 20.9, 'medv(id143)': 13.4, 'medv(id217)': 23.3, 'medv(id29)': 18.4, 'medv(id181)': 39.8, 'medv(id342)': 32.7, 'medv(id59)': 23.3, 'medv(id27)': 16.6, 'medv(id188)': 32.0, 'medv(id435)': 11.7, 'medv(id173)': 23.1, 'medv(id10)': 18.9})
 
-    def test_sigmoid(self):
-        """
-        tests: sigmoid function.
-        """
-        self.assertEqual(Utils.sigmoid(-5), 0.006692850924284856)
-        self.assertEqual(Utils.sigmoid(-0.001), 0.49975000002083336)
-        self.assertEqual(Utils.sigmoid(0), 0.5)
-        self.assertEqual(Utils.sigmoid(0.0001), 0.5000249999999792)
-        self.assertEqual(Utils.sigmoid(0.01), 0.5024999791668749)
-        self.assertEqual(Utils.sigmoid(0.5), 0.6224593312018546)
-        self.assertEqual(Utils.sigmoid(1), 0.7310585786300049)
-        self.assertEqual(Utils.sigmoid(5), 0.9933071490757152)
+
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`setTarget` function reduced from 25 lines to 9 (excluding comments, which made the total length about as long 😜). By only reasoning about the contents of the background, this function may be independent of classification or regression.

Added test cases for the `setTarget` function, but did not test the contents of `Data.variableType`.